### PR TITLE
Fix attempt #1: Setup pnpm step on ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3 # docs https://pnpm.io/continuous-integration#github-actions
+        with:
+            version: 9.4.0
+
       - name: Setup and Build
         uses: ./.github/actions/setup-and-build
 


### PR DESCRIPTION
Creating a step that explicitly pins pnpm version to match github workflow version of 9.4.0.