### PR TITLE
Ensure environment variables are included in bindings.sh

### DIFF
--- a/bindings.sh
+++ b/bindings.sh
@@ -2,6 +2,12 @@
 
 bindings=""
 
+# Check if .env.local exists
+if [ ! -f .env.local ]; then
+  echo "Error: .env.local file not found."
+  exit 1
+fi
+
 while IFS= read -r line || [ -n "$line" ]; do
   if [[ ! "$line" =~ ^# ]] && [[ -n "$line" ]]; then
     name=$(echo "$line" | cut -d '=' -f 1)


### PR DESCRIPTION
Updated `bindings.sh` to check for the existence of the `.env.local` file before reading it. This change prevents issues with missing environment variables by exiting with an error message if the file is not found. This ensures that all necessary environment variables are included during Docker usage.



Created with [**Solver**](https://solverai.com)